### PR TITLE
Fix values with commas breaking CSV output.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,13 @@
  */
 
 var isArray = Array.isArray
-  , keys = Object.keys
+  , keys = Object.keys;
 
 
 CSV.CHAR_RETURN = 0xd;
 CSV.CHAR_NEWLINE = 0xa;
 CSV.DELIMITER = 0x2c;
+CSV.CHAR_ENCAPSULATE = 0x22;
 
 
 function head (a) {
@@ -26,6 +27,18 @@ function char (c) {
 	         : c;
 }
 
+function needsEncapsulation (string) {
+	return string.toString().indexOf(char(CSV.DELIMITER)) >= 0;
+}
+
+function encapsulate (string, wrapperChar) {
+	var replaceWith = '\\' + wrapperChar;
+	var escapedValue = string.toString()
+													 .replace(new RegExp(wrapperChar, "g"), replaceWith);
+
+	return wrapperChar + escapedValue + wrapperChar;
+}
+
 /**
  * Parses an array of objects to a CSV output
  */
@@ -34,10 +47,10 @@ module.exports = CSV;
 function CSV (objects, opts) {
 	if ('object' !== typeof objects) throw new TypeError("expecting an array");
 
-	opts = 'object' === typeof opts 
+	opts = 'object' === typeof opts
 	        ? opts
 	        : {};
-	
+
 	objects = isArray(objects)
 	           ? objects
 	           : [objects];
@@ -45,15 +58,21 @@ function CSV (objects, opts) {
 	if (!objects.length) throw new Error("expecting at least one object");
 
 	var headers = keys(head(objects))
-	  , buf = []
+	  , buf = [];
 
 	while (objects.length) {
 		var lbuf = []
-		  , object = objects.shift()
+		  , object = objects.shift();
 
 		for (var i = 0 ;i < headers.length; ++i) {
-			var header = headers[i]
+			var header = headers[i];
+
 			if (lbuf.length) lbuf.push(char(CSV.DELIMITER));
+			object[header] = needsEncapsulation(object[header])
+												? encapsulate(object[header], char(CSV.CHAR_ENCAPSULATE))
+												: object[header];
+
+
 			lbuf.push(object[header]);
 		}
 


### PR DESCRIPTION
If a value is found to have a comma in it, the value will get
wrapped in quotation marks, and any quotation marks in the value
will be escaped.

Set it up to possilbly allow users to specify the encapsulation
character in the future.  There wasn't any documentation on the
supported opts (and no validation), so I wasn't sure how this
was supposed to be implemented.

I'd like to move the file to use all space indention or tab-based
indention, but I figured if we wanted to do that, it could be in
another commit.

Fixes jwerle/to-csv#1
